### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ branches:
 matrix:
     fast_finish: true
     include:
+        - php: 7.4
         - php: 7.3
         - php: 7.2
         - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*",
+        "phpunit/phpunit": "^4.8.36",
         "symfony/console": "~2.3|~3.0",
         "myclabs/php-enum": "~1.5",
         "marc-mabe/php-enum": "~2.3",
         "happy-types/enumerable-type": "~1.0",
         "scrutinizer/ocular": "~1.3",
-        "satooshi/php-coveralls": "^1.0",
+        "php-coveralls/php-coveralls": "^1.0",
         "phpbench/phpbench": "~0.12"
     }
 }

--- a/tests/Enum/AbcExpTest.php
+++ b/tests/Enum/AbcExpTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Enum\Tests\Enum;
 
 use GpsLab\Component\Enum\Tests\Fixture\Enum\AbcExp;
+use PHPUnit\Framework\TestCase;
 
-class AbcExpTest extends \PHPUnit_Framework_TestCase
+class AbcExpTest extends TestCase
 {
     /**
      * @var array

--- a/tests/Enum/AbcRefTest.php
+++ b/tests/Enum/AbcRefTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Enum\Tests\Enum;
 
 use GpsLab\Component\Enum\Tests\Fixture\Enum\AbcRef;
+use PHPUnit\Framework\TestCase;
 
-class AbcRefTest extends \PHPUnit_Framework_TestCase
+class AbcRefTest extends TestCase
 {
     /**
      * @var array

--- a/tests/Enum/ColorTest.php
+++ b/tests/Enum/ColorTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Enum\Tests\Enum;
 
 use GpsLab\Component\Enum\Tests\Fixture\Enum\ColorBW;
+use PHPUnit\Framework\TestCase;
 
-class ColorTest extends \PHPUnit_Framework_TestCase
+class ColorTest extends TestCase
 {
     /**
      * @var array

--- a/tests/Enum/ConstAccessTest.php
+++ b/tests/Enum/ConstAccessTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Enum\Tests\Enum;
 
 use GpsLab\Component\Enum\Tests\Fixture\Enum\ConstAccess;
+use PHPUnit\Framework\TestCase;
 
-class ConstAccessTest extends \PHPUnit_Framework_TestCase
+class ConstAccessTest extends TestCase
 {
     /**
      * @var array
@@ -24,7 +25,7 @@ class ConstAccessTest extends \PHPUnit_Framework_TestCase
      */
     private $names = [];
 
-    public function setUp()
+    protected function setUp()
     {
         if (PHP_VERSION_ID < 70100) {
             $this->markTestSkipped('This test is for PHP-7.1 and upper only');

--- a/tests/Set/AbcRefTest.php
+++ b/tests/Set/AbcRefTest.php
@@ -12,8 +12,9 @@ namespace GpsLab\Component\Enum\Tests\Set;
 
 use GpsLab\Component\Enum\Tests\Fixture\Set\AbcRef;
 use GpsLab\Component\Enum\Tests\Fixture\Set\DefRef;
+use PHPUnit\Framework\TestCase;
 
-class AbcRefTest extends \PHPUnit_Framework_TestCase
+class AbcRefTest extends TestCase
 {
     /**
      * @var array

--- a/tests/Set/ConstAccessTest.php
+++ b/tests/Set/ConstAccessTest.php
@@ -11,8 +11,9 @@
 namespace GpsLab\Component\Enum\Tests\Set;
 
 use GpsLab\Component\Enum\Tests\Fixture\Set\ConstAccess;
+use PHPUnit\Framework\TestCase;
 
-class ConstAccessTest extends \PHPUnit_Framework_TestCase
+class ConstAccessTest extends TestCase
 {
     public function testChoices()
     {


### PR DESCRIPTION
# Changed log
- The `satooshi/php-coveralls` is deprecated. Using the `php-coveralls/php-coveralls` instead.
- The `php-7.4` is stable now. Add this PHP version on Travis CI build.
- To be compatible with future PHPUnit version, using the `PHPUnit\Framework\TestCase` namespace.
- According [PHPUnit fixtures reference](https://phpunit.de/manual/4.8/en/fixtures.html), the `setUp` method is `protected`, not `public`.